### PR TITLE
Fix scroll view visibility

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,0 +1,7 @@
+# Change Log
+
+Details changes in each release of Sencha. Sencha follows [semantic versioning](http://semver.org/).
+
+## 0.3.1 (21/11/2017)
+
+* [Bugfix] Remove visibility matcher from scrolling action

--- a/Sencha.podspec
+++ b/Sencha.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'Sencha'
-  s.version      = '0.3.0'
+  s.version      = '0.3.1'
   s.summary      = 'The friendly version of EarlGrey'
 
   s.description  = <<-DESC

--- a/Sencha/Actions/SenchaScrollViewActions.swift
+++ b/Sencha/Actions/SenchaScrollViewActions.swift
@@ -42,11 +42,7 @@ public extension SenchaScrollViewActions {
             line: line
         ).usingSearch(
             grey_scrollInDirection(GREYDirection.down, CGFloat(distance)),
-            onElementWith: Matcher.allOf([
-                    scrollMatcher,
-                    .visible
-                ]
-            ).greyMatcher()
+            onElementWith: scrollMatcher.greyMatcher()
         )
     }
 }


### PR DESCRIPTION
There is no need to assert for scroll view visibility when scrolling it. Doing it was causing issues with scroll views partially covered by other elements for design purposes (as reported by @gerardpedreny).