### PR TITLE
changes replaceText to typeText

### DIFF
--- a/Sencha/Actions/SenchaEditTextActions.swift
+++ b/Sencha/Actions/SenchaEditTextActions.swift
@@ -15,7 +15,7 @@ public extension SenchaEditTextActions {
             file: file,
             line: line
         ).perform(
-            grey_replaceText(text)
+            grey_typeText(text)
         )
     }
 }


### PR DESCRIPTION
`grey_replaceText(text)` does not notify delegate methods, just replace the text. On the other hand, `grey_typeText(text)` inputs texts as a regular user would do.
