### PR TITLE
Feature/zero rows case

### DIFF
--- a/Sencha/Assertions/SenchaCollectionViewAssertions.swift
+++ b/Sencha/Assertions/SenchaCollectionViewAssertions.swift
@@ -13,14 +13,7 @@ public protocol SenchaCollectionViewAssertions: EarlGreyHumanizer {
 public extension SenchaCollectionViewAssertions {
 
     func assert(collectionViewWith matcher: Matcher, hasCellCount cellCount: Int, file: StaticString = #file, line: UInt = #line) {
-
-        assert(
-            collectionViewWith: matcher,
-            hasSectionCount: 1,
-            file: file,
-            line: line
-        )
-
+    
         assert(
             collectionViewWith: matcher,
             hasCellCount: cellCount,
@@ -28,6 +21,7 @@ public extension SenchaCollectionViewAssertions {
             file: file,
             line: line
         )
+        
     }
 
     func assert(collectionViewWith matcher: Matcher, hasCellCount cellCount: Int, inSection section: Int, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
### The problem
 self.assert(tableViewWith: TABLE_VIEW_MATCHER, hasRowCount: **0**)

If you check for 0 rows in a tableView, its not too obvious that the library is asserting that section.count == 1. Most os the times would be like this (delegate defaults to 1 section), but we have some serious problem to detect that when we have no sections this assertion fails. 

If user doesn't specify a section we can assume that they already know what they are doing and just ask for the first section(0). 

Maybe we can create another method like:
` self.assert(tableViewIsEmptyWith: TABLE_VIEW_MATCHER)`
but i think it would complicate the API a bit..?