### PR TITLE
Feature/assert empty table collection view

### DIFF
--- a/ExampleProject/MainViewController.swift
+++ b/ExampleProject/MainViewController.swift
@@ -10,7 +10,7 @@ class MainViewController: UIViewController, UITableViewDelegate, UITableViewData
     @IBOutlet weak var tableView: UITableView!
     
     @IBOutlet weak var editBarButton: UIBarButtonItem!
-    let rows: [Int] = Array(1...100)
+    var rows: [Int] = Array(1...100)
     
     var sectionTitle = "Normal Mode"
     
@@ -25,6 +25,10 @@ class MainViewController: UIViewController, UITableViewDelegate, UITableViewData
         
         sectionTitle = sectionTitle == "Normal Mode" ? "Edit Mode" : "Normal Mode"
         tableView.reloadData()
+    }
+
+    func clearTableView() {
+        rows = []
     }
     
     //MARK: TableViewDataSource

--- a/ExampleProjectTests/MainViewShould.swift
+++ b/ExampleProjectTests/MainViewShould.swift
@@ -5,7 +5,9 @@ import Sencha
 @testable import ExampleProject
 
 class MainViewShould: XCTestCase {
-    
+
+    let TABLE_VIEW_MATCHER = Matcher.accessibilityID(MainViewController.AccessibilityID.tableView)
+
     let storyboard = UIStoryboard(name: "Main", bundle: Bundle(for: MainViewController.self))
     var viewController: MainViewController!
 
@@ -19,27 +21,27 @@ class MainViewShould: XCTestCase {
 
     func test_be_able_to_assert_TableView_is_empty() {
         viewController.clearTableView()
-        assertTableViewIsEmpty(with: .accessibilityID(MainViewController.AccessibilityID.tableView))
+        assertTableViewIsEmpty(with: TABLE_VIEW_MATCHER)
     }
 
     func test_be_able_to_assert_TableView_is_not_empty() {
 
-        assertTableViewIsNotEmpty(with: .accessibilityID(MainViewController.AccessibilityID.tableView))
+        assertTableViewIsNotEmpty(with: TABLE_VIEW_MATCHER)
     }
 
     func test_be_able_to_assert_the_number_of_rows() {
         
-        assert(tableViewWith: .accessibilityID(MainViewController.AccessibilityID.tableView), hasRowCount: 100)
+        assert(tableViewWith: TABLE_VIEW_MATCHER, hasRowCount: 100)
     }
     
     func test_be_able_to_assert_the_number_of_sections() {
         
-        assert(tableViewWith: .accessibilityID(MainViewController.AccessibilityID.tableView), hasSectionCount: 1)
+        assert(tableViewWith: TABLE_VIEW_MATCHER, hasSectionCount: 1)
     }
     
     func test_be_able_to_scroll_to_an_offscreen_cell_and_verify_the_content() {
     
-        assertVisible(.text("20"), inScrollableElementWith: .accessibilityID(MainViewController.AccessibilityID.tableView))
+        assertVisible(.text("20"), inScrollableElementWith: TABLE_VIEW_MATCHER)
     }
     
     func test_be_able_to_tap_elements_and_verify_the_result() {
@@ -49,8 +51,8 @@ class MainViewShould: XCTestCase {
     }
     
     func test_be_able_to_navigate_to_a_detail_view() {
-        
-        tap(.text("12"), inScrollableElementWith: .accessibilityID(MainViewController.AccessibilityID.tableView))
+
+        tap(.text("12"), inScrollableElementWith: TABLE_VIEW_MATCHER)
         assertVisible(.text("Detail"))
     }
 
@@ -58,7 +60,7 @@ class MainViewShould: XCTestCase {
 
         assertVisible(.text("Sencha Example"))
 
-        tap(.text("12"), inScrollableElementWith: .accessibilityID(MainViewController.AccessibilityID.tableView))
+        tap(.text("12"), inScrollableElementWith: TABLE_VIEW_MATCHER)
         assertVisible(.text("Detail"))
         tapBackButton()
 

--- a/ExampleProjectTests/MainViewShould.swift
+++ b/ExampleProjectTests/MainViewShould.swift
@@ -7,15 +7,26 @@ import Sencha
 class MainViewShould: XCTestCase {
     
     let storyboard = UIStoryboard(name: "Main", bundle: Bundle(for: MainViewController.self))
-    
+    var viewController: MainViewController!
+
     override func setUp() {
         super.setUp()
         
-        let viewController = storyboard.instantiateViewController(withIdentifier: "MainNavigationController")
-        
-        open(viewController: viewController)
+        let navigationController = storyboard.instantiateViewController(withIdentifier: "MainNavigationController") as! UINavigationController
+        viewController = navigationController.viewControllers.first as? MainViewController
+        open(viewController: navigationController)
     }
-    
+
+    func test_be_able_to_assert_TableView_is_empty() {
+        viewController.clearTableView()
+        assertTableViewIsEmpty(with: .accessibilityID(MainViewController.AccessibilityID.tableView))
+    }
+
+    func test_be_able_to_assert_TableView_is_not_empty() {
+
+        assertTableViewIsNotEmpty(with: .accessibilityID(MainViewController.AccessibilityID.tableView))
+    }
+
     func test_be_able_to_assert_the_number_of_rows() {
         
         assert(tableViewWith: .accessibilityID(MainViewController.AccessibilityID.tableView), hasRowCount: 100)

--- a/README.markdown
+++ b/README.markdown
@@ -96,6 +96,8 @@ assertNotVisible(.text("EmptyStateText"), inScrollableElementWith: .accessibilit
 assert(tableViewWith: .accessibilityID("TableViewID"), hasRowCount: 30)
 assert(tableViewWith: .accessibilityID("TableViewID"), hasRowCount: 30, inSection: 1)
 assert(tableViewWith: .accessibilityID("TableViewID"), hasSectionCount: 2)
+assertTableViewIsEmpty(with: .accessibilityID("TableViewID"))
+assertTableViewIsNotEmpty(with: .accessibilityID("TableViewID"))
 
 ```
 
@@ -106,6 +108,8 @@ assert(tableViewWith: .accessibilityID("TableViewID"), hasSectionCount: 2)
 assert(collectionViewWith: .accessibilityID("CollectionViewID"), hasCellCount: 30)
 assert(collectionViewWith: .accessibilityID("CollectionViewID"), hasCellCount: 30, inSection: 1)
 assert(collectionViewWith: .accessibilityID("CollectionViewID"), hasSectionCount: 2)
+assertCollectionViewIsEmpty(with: .accessibilityID("CollectionViewID"))
+assertCollectionViewIsNotEmpty(with: .accessibilityID("CollectionViewID"))
 
 ```
 

--- a/README.markdown
+++ b/README.markdown
@@ -93,12 +93,8 @@ assertNotVisible(.text("EmptyStateText"), inScrollableElementWith: .accessibilit
 
 ```swift
 
-//This assertion also verifies that the table view has only one section, 2 good assertions in 1 :)
 assert(tableViewWith: .accessibilityID("TableViewID"), hasRowCount: 30)
-
-//This assertion does the same as the previous one but you can specify the section.
 assert(tableViewWith: .accessibilityID("TableViewID"), hasRowCount: 30, inSection: 1)
-
 assert(tableViewWith: .accessibilityID("TableViewID"), hasSectionCount: 2)
 
 ```

--- a/Sencha/Assertions/SenchaCollectionViewAssertions.swift
+++ b/Sencha/Assertions/SenchaCollectionViewAssertions.swift
@@ -4,6 +4,8 @@ import EarlGrey
 
 public protocol SenchaCollectionViewAssertions: EarlGreyHumanizer {
 
+    func assertCollectionViewIsEmpty(with matcher: Matcher, file: StaticString, line: UInt)
+    func assertCollectionViewIsNotEmpty(with matcher: Matcher, file: StaticString, line: UInt)
     func assert(collectionViewWith matcher: Matcher, hasCellCount cellCount: Int, file: StaticString, line: UInt)
     func assert(collectionViewWith matcher: Matcher, hasCellCount cellCount: Int, inSection section: Int, file: StaticString, line: UInt)
     func assert(collectionViewWith matcher: Matcher, hasSectionCount sectionCount: Int, file: StaticString, line: UInt)
@@ -11,6 +13,28 @@ public protocol SenchaCollectionViewAssertions: EarlGreyHumanizer {
 }
 
 public extension SenchaCollectionViewAssertions {
+
+    func assertCollectionViewIsEmpty(with matcher: Matcher, file: StaticString = #file, line: UInt = #line) {
+        assert(collectionViewWith: matcher, hasCellCount: 0, file: file, line: line)
+    }
+
+    func assertCollectionViewIsNotEmpty(with matcher: Matcher, file: StaticString = #file, line: UInt = #line) {
+        let cellCountAssert = GREYAssertionBlock(name: "CollectionView is not empty") { (element, error) -> Bool in
+            if let collectionView = element as? UICollectionView {
+                let numberOfCells = collectionView.numberOfItems(inSection: 0)
+                return numberOfCells > 0
+            }
+            return false
+        }
+
+        select(
+            matcher,
+            file: file,
+            line: line
+        ).assert(
+            cellCountAssert
+        )
+    }
 
     func assert(collectionViewWith matcher: Matcher, hasCellCount cellCount: Int, file: StaticString = #file, line: UInt = #line) {
     
@@ -21,7 +45,6 @@ public extension SenchaCollectionViewAssertions {
             file: file,
             line: line
         )
-        
     }
 
     func assert(collectionViewWith matcher: Matcher, hasCellCount cellCount: Int, inSection section: Int, file: StaticString = #file, line: UInt = #line) {
@@ -38,8 +61,8 @@ public extension SenchaCollectionViewAssertions {
             matcher,
             file: file,
             line: line
-            ).assert(
-                cellCountAssert
+        ).assert(
+            cellCountAssert
         )
     }
 
@@ -57,8 +80,8 @@ public extension SenchaCollectionViewAssertions {
             matcher,
             file: file,
             line: line
-            ).assert(
-                sectionCountAssert
+        ).assert(
+            sectionCountAssert
         )
     }
 }

--- a/Sencha/Assertions/SenchaTableViewAssertions.swift
+++ b/Sencha/Assertions/SenchaTableViewAssertions.swift
@@ -3,7 +3,9 @@ import UIKit
 import EarlGrey
 
 public protocol SenchaTableViewAssertions: EarlGreyHumanizer {
-    
+
+    func assertTableViewIsEmpty(with matcher: Matcher, file: StaticString, line: UInt)
+    func assertTableViewIsNotEmpty(with matcher: Matcher, file: StaticString, line: UInt)
     func assert(tableViewWith matcher: Matcher, hasRowCount rowCount: Int, file: StaticString, line: UInt)
     func assert(tableViewWith matcher: Matcher, hasRowCount rowCount: Int, inSection section: Int, file: StaticString, line: UInt)
     func assert(tableViewWith matcher: Matcher, hasSectionCount sectionCount: Int, file: StaticString, line: UInt)
@@ -11,7 +13,29 @@ public protocol SenchaTableViewAssertions: EarlGreyHumanizer {
 }
 
 public extension SenchaTableViewAssertions {
-    
+
+    func assertTableViewIsEmpty(with matcher: Matcher, file: StaticString = #file, line: UInt = #line) {
+        assert(tableViewWith: matcher, hasRowCount: 0, file: file, line: line)
+    }
+
+    func assertTableViewIsNotEmpty(with matcher: Matcher, file: StaticString = #file, line: UInt = #line) {
+        let cellCountAssert = GREYAssertionBlock(name: "TableView is not empty") { (element, error) -> Bool in
+            if let tableView = element as? UITableView {
+                let numberOfCells = tableView.numberOfRows(inSection: 0)
+                return numberOfCells > 0
+            }
+            return false
+        }
+
+        select(
+            matcher,
+            file: file,
+            line: line
+        ).assert(
+            cellCountAssert
+        )
+    }
+
     func assert(tableViewWith matcher: Matcher, hasRowCount rowCount: Int, file: StaticString = #file, line: UInt = #line) {
         
         assert(

--- a/Sencha/Assertions/SenchaTableViewAssertions.swift
+++ b/Sencha/Assertions/SenchaTableViewAssertions.swift
@@ -16,13 +16,6 @@ public extension SenchaTableViewAssertions {
         
         assert(
             tableViewWith: matcher,
-            hasSectionCount: 1,
-            file: file,
-            line: line
-        )
-        
-        assert(
-            tableViewWith: matcher,
             hasRowCount: rowCount,
             inSection: 0,
             file: file,


### PR DESCRIPTION
In order to address the issue found in: https://github.com/SchibstedSpain/Sencha/pull/10 🙇🏻‍♂️, I've fixed the current API and added special methods for the empty/not empty cases which can be useful to give a more meaningful syntax to the tests 🎉