### PR TITLE
Update SenchaScrollingAssertion.swift

### DIFF
--- a/Sencha/Assertions/SenchaScrollingAssertion.swift
+++ b/Sencha/Assertions/SenchaScrollingAssertion.swift
@@ -13,7 +13,7 @@ public extension SenchaScrollableAssertion {
     func assertVisible(_ matcher: Matcher, inScrollableElementWith scrollMatcher: Matcher, file: StaticString = #file, line: UInt = #line) {
         
         scrollTo(
-            matcher,
+            .allOf([matcher, .visible]),
             inElementWith: scrollMatcher,
             file: file,
             line: line


### PR DESCRIPTION
To be sure than a matcher is visible when is scrolling, we add an array of 2 matches as a matcher: The original matcher and the "visible" one.