### PR TITLE
Add new actions and matchers

### DIFF
--- a/ExampleProject/Base.lproj/Main.storyboard
+++ b/ExampleProject/Base.lproj/Main.storyboard
@@ -99,18 +99,27 @@
                                     <constraint firstAttribute="width" constant="114" id="5pm-XE-tcH"/>
                                 </constraints>
                             </slider>
+                            <datePicker contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="ATx-tg-mIG">
+                                <rect key="frame" x="0.0" y="451" width="375" height="216"/>
+                                <date key="date" timeIntervalSinceReferenceDate="570980831.65727603">
+                                    <!--2019-02-04 13:47:11 +0000-->
+                                </date>
+                            </datePicker>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="28X-di-zDY" firstAttribute="top" secondItem="rUi-49-s7f" secondAttribute="bottom" constant="30" id="1Ga-5v-6xl"/>
                             <constraint firstItem="cvk-6B-uzh" firstAttribute="top" secondItem="Yyt-Rd-hfc" secondAttribute="bottom" constant="18" id="5z1-tA-kHK"/>
                             <constraint firstItem="28X-di-zDY" firstAttribute="centerX" secondItem="qCF-c5-j0j" secondAttribute="centerX" id="BZo-I1-h5N"/>
+                            <constraint firstAttribute="trailing" secondItem="ATx-tg-mIG" secondAttribute="trailing" id="QU1-Pr-Nci"/>
                             <constraint firstItem="YZz-va-XsP" firstAttribute="centerX" secondItem="qCF-c5-j0j" secondAttribute="centerX" id="T55-BY-rZA"/>
                             <constraint firstItem="MFy-gJ-0Tm" firstAttribute="top" secondItem="KEI-Vp-cf6" secondAttribute="bottom" constant="26" id="aXq-yN-a8Z"/>
                             <constraint firstItem="Yyt-Rd-hfc" firstAttribute="centerX" secondItem="qCF-c5-j0j" secondAttribute="centerX" id="eFG-G0-0x0"/>
                             <constraint firstItem="MFy-gJ-0Tm" firstAttribute="centerX" secondItem="qCF-c5-j0j" secondAttribute="centerX" id="jwD-as-OkG"/>
+                            <constraint firstItem="ATx-tg-mIG" firstAttribute="leading" secondItem="qCF-c5-j0j" secondAttribute="leading" id="nma-5F-tNh"/>
                             <constraint firstItem="Yyt-Rd-hfc" firstAttribute="top" secondItem="28X-di-zDY" secondAttribute="bottom" constant="16" id="nne-aS-VID"/>
                             <constraint firstItem="YZz-va-XsP" firstAttribute="top" secondItem="cvk-6B-uzh" secondAttribute="bottom" constant="14" id="o75-nx-Flz"/>
+                            <constraint firstItem="ro0-Dd-P9k" firstAttribute="top" secondItem="ATx-tg-mIG" secondAttribute="bottom" id="qyU-Se-9d2"/>
                             <constraint firstItem="cvk-6B-uzh" firstAttribute="centerX" secondItem="qCF-c5-j0j" secondAttribute="centerX" id="tF0-zG-X7R"/>
                             <constraint firstItem="KEI-Vp-cf6" firstAttribute="centerX" secondItem="qCF-c5-j0j" secondAttribute="centerX" id="tv4-3l-btx"/>
                             <constraint firstItem="KEI-Vp-cf6" firstAttribute="top" secondItem="YZz-va-XsP" secondAttribute="bottom" constant="20" id="zFY-bk-ukr"/>
@@ -118,6 +127,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="9eT-hC-xq8"/>
                     <connections>
+                        <outlet property="datePicker" destination="ATx-tg-mIG" id="vTT-83-z8o"/>
                         <outlet property="slider" destination="MFy-gJ-0Tm" id="kWR-WA-Qs4"/>
                         <outlet property="switchOn" destination="KEI-Vp-cf6" id="hbQ-g9-03d"/>
                         <outlet property="textField" destination="Yyt-Rd-hfc" id="Vqe-QF-9Oh"/>

--- a/ExampleProject/Base.lproj/Main.storyboard
+++ b/ExampleProject/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="CsI-lX-C1m">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="CsI-lX-C1m">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -78,22 +78,27 @@
                                 <state key="normal" title="This is an enabled button"/>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YZz-va-XsP">
-                                <rect key="frame" x="104" y="223" width="168" height="30"/>
+                                <rect key="frame" x="103.5" y="223" width="168" height="30"/>
                                 <state key="normal" title="This is a disabled button"/>
                             </button>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Some placeholder text" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Yyt-Rd-hfc">
                                 <rect key="frame" x="67.5" y="131" width="240" height="30"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="240" id="7yh-b8-F5W"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="240" id="7yh-b8-F5W"/>
                                 </constraints>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KEI-Vp-cf6">
-                                <rect key="frame" x="164" y="273" width="49" height="31"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KEI-Vp-cf6">
+                                <rect key="frame" x="163" y="273" width="51" height="31"/>
                             </switch>
+                            <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="MFy-gJ-0Tm">
+                                <rect key="frame" x="128" y="330" width="118" height="31"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="114" id="5pm-XE-tcH"/>
+                                </constraints>
+                            </slider>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
@@ -101,14 +106,19 @@
                             <constraint firstItem="cvk-6B-uzh" firstAttribute="top" secondItem="Yyt-Rd-hfc" secondAttribute="bottom" constant="18" id="5z1-tA-kHK"/>
                             <constraint firstItem="28X-di-zDY" firstAttribute="centerX" secondItem="qCF-c5-j0j" secondAttribute="centerX" id="BZo-I1-h5N"/>
                             <constraint firstItem="YZz-va-XsP" firstAttribute="centerX" secondItem="qCF-c5-j0j" secondAttribute="centerX" id="T55-BY-rZA"/>
+                            <constraint firstItem="MFy-gJ-0Tm" firstAttribute="top" secondItem="KEI-Vp-cf6" secondAttribute="bottom" constant="26" id="aXq-yN-a8Z"/>
                             <constraint firstItem="Yyt-Rd-hfc" firstAttribute="centerX" secondItem="qCF-c5-j0j" secondAttribute="centerX" id="eFG-G0-0x0"/>
+                            <constraint firstItem="MFy-gJ-0Tm" firstAttribute="centerX" secondItem="qCF-c5-j0j" secondAttribute="centerX" id="jwD-as-OkG"/>
                             <constraint firstItem="Yyt-Rd-hfc" firstAttribute="top" secondItem="28X-di-zDY" secondAttribute="bottom" constant="16" id="nne-aS-VID"/>
                             <constraint firstItem="YZz-va-XsP" firstAttribute="top" secondItem="cvk-6B-uzh" secondAttribute="bottom" constant="14" id="o75-nx-Flz"/>
                             <constraint firstItem="cvk-6B-uzh" firstAttribute="centerX" secondItem="qCF-c5-j0j" secondAttribute="centerX" id="tF0-zG-X7R"/>
+                            <constraint firstItem="KEI-Vp-cf6" firstAttribute="centerX" secondItem="qCF-c5-j0j" secondAttribute="centerX" id="tv4-3l-btx"/>
+                            <constraint firstItem="KEI-Vp-cf6" firstAttribute="top" secondItem="YZz-va-XsP" secondAttribute="bottom" constant="20" id="zFY-bk-ukr"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="9eT-hC-xq8"/>
                     <connections>
+                        <outlet property="slider" destination="MFy-gJ-0Tm" id="kWR-WA-Qs4"/>
                         <outlet property="switchOn" destination="KEI-Vp-cf6" id="hbQ-g9-03d"/>
                         <outlet property="textField" destination="Yyt-Rd-hfc" id="Vqe-QF-9Oh"/>
                     </connections>

--- a/ExampleProject/Base.lproj/Main.storyboard
+++ b/ExampleProject/Base.lproj/Main.storyboard
@@ -94,7 +94,7 @@
                                 <rect key="frame" x="163" y="273" width="51" height="31"/>
                             </switch>
                             <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="MFy-gJ-0Tm">
-                                <rect key="frame" x="128" y="330" width="118" height="31"/>
+                                <rect key="frame" x="128.5" y="330" width="118" height="31"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="114" id="5pm-XE-tcH"/>
                                 </constraints>

--- a/ExampleProject/DetailViewController.swift
+++ b/ExampleProject/DetailViewController.swift
@@ -5,11 +5,13 @@ class DetailViewController: UIViewController {
 
     @IBOutlet weak var textField: UITextField!
     @IBOutlet weak var switchOn: UISwitch!
+    @IBOutlet weak var slider: UISlider!
 
     struct AccessibilityID {
 
         static let textField = "DetailViewController.textField"
         static let switchOn = "DetailViewController.switchOn"
+        static let slider = "DetailViewController.slider"
     }
 
     override func viewDidLoad() {
@@ -18,5 +20,6 @@ class DetailViewController: UIViewController {
         title = "Detail"
         textField.accessibilityIdentifier = AccessibilityID.textField
         switchOn.accessibilityIdentifier = AccessibilityID.switchOn
+        slider.accessibilityIdentifier = AccessibilityID.slider
     }
 }

--- a/ExampleProject/DetailViewController.swift
+++ b/ExampleProject/DetailViewController.swift
@@ -6,12 +6,14 @@ class DetailViewController: UIViewController {
     @IBOutlet weak var textField: UITextField!
     @IBOutlet weak var switchOn: UISwitch!
     @IBOutlet weak var slider: UISlider!
+    @IBOutlet weak var datePicker: UIDatePicker!
 
     struct AccessibilityID {
 
         static let textField = "DetailViewController.textField"
         static let switchOn = "DetailViewController.switchOn"
         static let slider = "DetailViewController.slider"
+        static let datePicker = "DetailViewController.datePicker"
     }
 
     override func viewDidLoad() {
@@ -21,5 +23,6 @@ class DetailViewController: UIViewController {
         textField.accessibilityIdentifier = AccessibilityID.textField
         switchOn.accessibilityIdentifier = AccessibilityID.switchOn
         slider.accessibilityIdentifier = AccessibilityID.slider
+        datePicker.accessibilityIdentifier = AccessibilityID.datePicker
     }
 }

--- a/ExampleProjectTests/DetailViewShould.swift
+++ b/ExampleProjectTests/DetailViewShould.swift
@@ -34,7 +34,7 @@ class ViewDetailShould: XCTestCase {
         assertVisible(.text("I am typing stuff!!"))
     }
 
-    func test_show_a_swicth_with_on_state_and_turn_onto_off_state() {
+    func test_show_a_switch_with_on_state_and_turn_onto_off_state() {
         assertSwitchIsOn(.accessibilityID(DetailViewController.AccessibilityID.switchOn))
 
         tap(.accessibilityID(DetailViewController.AccessibilityID.switchOn))

--- a/ExampleProjectTests/DetailViewShould.swift
+++ b/ExampleProjectTests/DetailViewShould.swift
@@ -56,7 +56,13 @@ class ViewDetailShould: XCTestCase {
 
     func test_be_able_to_slide_a_slider() {
         assertSlider(slider, hasValue: .equalTo(0.5))
+        moveSlider(slider, to: 1)
+        assertSlider(slider, hasValue: .equalTo(1))
+    }
+
+    func test_be_able_to_validate_a_slider_value() {
         assertSlider(slider, hasValue: .greaterThan(0.0))
+        assertSlider(slider, hasValue: .equalTo(0.5))
         assertSlider(slider, hasValue: .lessThan(1.0))
     }
 }

--- a/ExampleProjectTests/DetailViewShould.swift
+++ b/ExampleProjectTests/DetailViewShould.swift
@@ -68,6 +68,8 @@ class ViewDetailShould: XCTestCase {
     }
 
     func test_be_able_to_change_a_pickers_value() {
-        movePicker(picker, to: Date(timeIntervalSince1970: 0))
+        let theBeginningOfTimes = Date(timeIntervalSince1970: 0)
+        movePicker(picker, to: theBeginningOfTimes)
+        assertPicker(picker, hasValue: theBeginningOfTimes)
     }
 }

--- a/ExampleProjectTests/DetailViewShould.swift
+++ b/ExampleProjectTests/DetailViewShould.swift
@@ -9,6 +9,7 @@ class ViewDetailShould: XCTestCase {
     let storyboard = UIStoryboard(name: "Main", bundle: Bundle(for: MainViewController.self))
     let textFieldMatcher = Matcher.accessibilityID(DetailViewController.AccessibilityID.textField)
     let slider = Matcher.accessibilityID(DetailViewController.AccessibilityID.slider)
+    let picker = Matcher.accessibilityID(DetailViewController.AccessibilityID.datePicker)
     
     override func setUp() {
         super.setUp()
@@ -64,5 +65,9 @@ class ViewDetailShould: XCTestCase {
         assertSlider(slider, hasValue: .greaterThan(0.0))
         assertSlider(slider, hasValue: .equalTo(0.5))
         assertSlider(slider, hasValue: .lessThan(1.0))
+    }
+
+    func test_be_able_to_change_a_pickers_value() {
+        movePicker(picker, to: Date(timeIntervalSince1970: 0))
     }
 }

--- a/ExampleProjectTests/DetailViewShould.swift
+++ b/ExampleProjectTests/DetailViewShould.swift
@@ -8,6 +8,7 @@ class ViewDetailShould: XCTestCase {
     
     let storyboard = UIStoryboard(name: "Main", bundle: Bundle(for: MainViewController.self))
     let textFieldMatcher = Matcher.accessibilityID(DetailViewController.AccessibilityID.textField)
+    let slider = Matcher.accessibilityID(DetailViewController.AccessibilityID.slider)
     
     override func setUp() {
         super.setUp()
@@ -27,11 +28,11 @@ class ViewDetailShould: XCTestCase {
     func test_show_an_interactable_text_field() {
 
         type(
-            text: "I am typing stuff!!",
+            text: "text",
             inElementWith: textFieldMatcher
         )
 
-        assertVisible(.text("I am typing stuff!!"))
+        assertVisible(.text("text"))
     }
 
     func test_show_a_switch_with_on_state_and_turn_onto_off_state() {
@@ -51,5 +52,11 @@ class ViewDetailShould: XCTestCase {
         clearTextInElement(with: textFieldMatcher)
         
         assertNotVisible(.text("text"))
+    }
+
+    func test_be_able_to_slide_a_slider() {
+        assertSlider(slider, hasValue: .equalTo(0.5))
+        assertSlider(slider, hasValue: .greaterThan(0.0))
+        assertSlider(slider, hasValue: .lessThan(1.0))
     }
 }

--- a/README.markdown
+++ b/README.markdown
@@ -60,9 +60,21 @@ scrollToRight(in: .accessibilityID("TableViewID"))
 
 ### Text actions
 
+⚠️ Use this method if you need the delegate methods of the text input to be triggered (otherwise use insertText below)
+This method uses the simulator's keyboard to type, and depending on the text it might fail.
 ```swift
 
 type("Username", inElementWith: .accessibilityID("UsernameTextFieldID"))
+
+```
+⚠️ Use this method if you don't need the delegate methods of the text input to be triggered.
+```swift
+
+insertText("Username", inElementWith: .accessibilityID("UsernameTextFieldID"))
+
+```
+```swift
+
 clearTextInElement(.accessibilityID("UsernameTextFieldID"))
 
 ```
@@ -134,8 +146,8 @@ assertCollectionViewIsNotEmpty(with: .accessibilityID("CollectionViewID"))
 ### Verifying Switch state
 ```swift
 
- assertSwitchIsOn(.accessibilityID("SwitchID"))
- assertSwitchIsOff(.accessibilityID("SwitchID"))
+assertSwitchIsOn(.accessibilityID("SwitchID"))
+assertSwitchIsOff(.accessibilityID("SwitchID"))
  
 ```
 

--- a/README.markdown
+++ b/README.markdown
@@ -78,7 +78,16 @@ tapKeyboardReturnKey()
 
 ```swift
 
-moveSlider(slider, to: 0.5)
+moveSlider(.accessibilityID("SliderID"), to: 0.5)
+
+```
+
+### Interacting with pickers
+
+```swift
+
+movePicker(.accessibilityID("PickerID"), to: Date())
+movePicker(.accessibilityID("PickerID"), column: 1, to: "10")
 
 ```
 

--- a/README.markdown
+++ b/README.markdown
@@ -120,6 +120,13 @@ assertCollectionViewIsNotEmpty(with: .accessibilityID("CollectionViewID"))
  assertSwitchIsOff(.accessibilityID("SwitchID"))
 ```
 
+### Verifying Slider value
+```
+assertSlider(slider, hasValue: .equalTo(0.5))
+assertSlider(slider, hasValue: .greaterThan(0.0))
+assertSlider(slider, hasValue: .lessThan(1.0))
+```
+
 ## Sencha's matchers
 
 In order to find interface elements and perform actions on them, we need some matchers. In other libraries this is achieved by finding an element via the _accessibilityLabel_ property of a view, but this property is meant for VoiceOver, and shouldn't be used for testing.

--- a/README.markdown
+++ b/README.markdown
@@ -74,6 +74,14 @@ tapKeyboardReturnKey()
 
 ```
 
+### Interacting with sliders
+
+```swift
+
+moveSlider(slider, to: 0.5)
+
+```
+
 ## Sencha's assertions
 
 ```swift
@@ -116,15 +124,19 @@ assertCollectionViewIsNotEmpty(with: .accessibilityID("CollectionViewID"))
 
 ### Verifying Switch state
 ```swift
+
  assertSwitchIsOn(.accessibilityID("SwitchID"))
  assertSwitchIsOff(.accessibilityID("SwitchID"))
+ 
 ```
 
 ### Verifying Slider value
-```
+```swift
+
 assertSlider(slider, hasValue: .equalTo(0.5))
 assertSlider(slider, hasValue: .greaterThan(0.0))
 assertSlider(slider, hasValue: .lessThan(1.0))
+
 ```
 
 ## Sencha's matchers

--- a/README.markdown
+++ b/README.markdown
@@ -142,9 +142,18 @@ assertCollectionViewIsNotEmpty(with: .accessibilityID("CollectionViewID"))
 ### Verifying Slider value
 ```swift
 
-assertSlider(slider, hasValue: .equalTo(0.5))
-assertSlider(slider, hasValue: .greaterThan(0.0))
-assertSlider(slider, hasValue: .lessThan(1.0))
+assertSlider(.accessibilityID("SliderID"), hasValue: .equalTo(0.5))
+assertSlider(.accessibilityID("SliderID"), hasValue: .greaterThan(0.0))
+assertSlider(.accessibilityID("SliderID"), hasValue: .lessThan(1.0))
+
+```
+
+### Verifying Picker value
+
+```swift 
+
+assertPicker(.accessibilityID("pickerID"), hasValue: Date())
+assertPicker(.accessibilityID("pickerID"), hasValue: "10", inColumn: 1)
 
 ```
 

--- a/Sencha/Actions/SenchaEditTextActions.swift
+++ b/Sencha/Actions/SenchaEditTextActions.swift
@@ -4,11 +4,23 @@ import EarlGrey
 public protocol SenchaEditTextActions: EarlGreyHumanizer {
     
     func type(text: String, inElementWith matcher: Matcher, file: StaticString, line: UInt)
+    func insertText(text: String, inElementWith matcher: Matcher, file: StaticString, line: UInt)
     func clearTextInElement(with matcher: Matcher, file: StaticString, line: UInt)
 }
 
 public extension SenchaEditTextActions {
-    
+
+    func insertText(text: String, inElementWith matcher: Matcher, file: StaticString = #file, line: UInt = #line) {
+
+        select(
+            matcher,
+            file: file,
+            line: line
+        ).perform(
+            grey_replaceText(text)
+        )
+    }
+
     func type(text: String, inElementWith matcher: Matcher, file: StaticString = #file, line: UInt = #line) {
         
         select(

--- a/Sencha/Actions/SenchaPickerActions.swift
+++ b/Sencha/Actions/SenchaPickerActions.swift
@@ -1,0 +1,31 @@
+import Foundation
+import EarlGrey
+
+public protocol SenchaPickerActions: EarlGreyHumanizer {
+
+    func movePicker(_ pickerMatcher: Matcher, to date: Date, file: StaticString, line: UInt)
+    func movePicker(_ pickerMatcher: Matcher, column: Int, to value: String, file: StaticString, line: UInt)
+}
+
+public extension SenchaPickerActions {
+
+    func movePicker(_ pickerMatcher: Matcher, to date: Date, file: StaticString = #file, line: UInt = #line) {
+        select(
+            pickerMatcher,
+            file: file,
+            line: line
+        ).perform(
+            .setPickerDateTo(date)
+        )
+    }
+
+    func movePicker(_ pickerMatcher: Matcher, column: Int, to value: String, file: StaticString = #file, line: UInt = #line) {
+        select(
+            pickerMatcher,
+            file: file,
+            line: line
+        ).perform(
+            .setPickerColumnToValue(column, value)
+        )
+    }
+}

--- a/Sencha/Actions/SenchaSliderActions.swift
+++ b/Sencha/Actions/SenchaSliderActions.swift
@@ -1,0 +1,20 @@
+import Foundation
+import EarlGrey
+
+public protocol SenchaSliderActions: EarlGreyHumanizer {
+
+    func moveSlider(_ sliderMatcher: Matcher, to value: Double, file: StaticString, line: UInt)
+}
+
+public extension SenchaSliderActions {
+
+    func moveSlider(_ sliderMatcher: Matcher, to value: Double, file: StaticString = #file, line: UInt = #line) {
+        select(
+            sliderMatcher,
+            file: file,
+            line: line
+        ).perform(
+            .moveSliderToValue(value)
+        )
+    }
+}

--- a/Sencha/Actions/SenchaSwipeActions.swift
+++ b/Sencha/Actions/SenchaSwipeActions.swift
@@ -3,7 +3,7 @@ import EarlGrey
 
 public protocol SenchaSwipeActions: EarlGreyHumanizer {
 
-    func swipe(_ matcher: Matcher, inDirection direction: SenchaDirection,file: StaticString, line: UInt)
+    func swipe(_ matcher: Matcher, inDirection direction: SenchaDirection, file: StaticString, line: UInt)
 }
 
 public extension SenchaSwipeActions {

--- a/Sencha/Assertions/SenchaPickerAssertions.swift
+++ b/Sencha/Assertions/SenchaPickerAssertions.swift
@@ -1,0 +1,32 @@
+import Foundation
+import EarlGrey
+
+public protocol SenchaPickerAssertions: EarlGreyHumanizer {
+    func assertPicker(_ pickerMatcher: Matcher, hasValue value: Date, file: StaticString, line: UInt)
+    func assertPicker(_ pickerMatcher: Matcher, hasValue value: String, inColumn column: Int, file: StaticString, line: UInt)
+}
+
+public extension SenchaPickerAssertions {
+
+    func assertPicker(_ pickerMatcher: Matcher, hasValue value: Date, file: StaticString = #file, line: UInt = #line) {
+
+        select(
+            pickerMatcher,
+            file: file,
+            line: line
+        ).assert(
+            .datePickerValue(value)
+        )
+    }
+
+    func assertPicker(_ pickerMatcher: Matcher, hasValue value: String, inColumn column: Int, file: StaticString = #file, line: UInt = #line) {
+
+        select(
+            pickerMatcher,
+            file: file,
+            line: line
+        ).assert(
+            .pickerColumnValue(column, value)
+        )
+    }
+}

--- a/Sencha/Assertions/SenchaSliderAssertions.swift
+++ b/Sencha/Assertions/SenchaSliderAssertions.swift
@@ -1,0 +1,20 @@
+import Foundation
+import EarlGrey
+
+public protocol SenchaSliderAssertions: EarlGreyHumanizer {
+    func assertSlider(_ sliderMatcher: Matcher, hasValue valueMatcher: ValueMatcher, file: StaticString, line: UInt)
+}
+
+public extension SenchaSliderAssertions {
+
+    func assertSlider(_ sliderMatcher: Matcher, hasValue valueMatcher: ValueMatcher, file: StaticString = #file, line: UInt = #line) {
+
+        select(
+            sliderMatcher,
+            file: file,
+            line: line
+        ).assert(
+            .sliderValue(valueMatcher)
+        )
+    }
+}

--- a/Sencha/Assertions/SenchaSwitchAssertions.swift
+++ b/Sencha/Assertions/SenchaSwitchAssertions.swift
@@ -24,7 +24,7 @@ public extension SenchaSwitchAssertions {
             file: file,
             line: line
         ).assert(
-            .not(.switchOn)
+            .switchOff
         )
     }
 }

--- a/Sencha/Extensions/XCTestCase+Sencha.swift
+++ b/Sencha/Extensions/XCTestCase+Sencha.swift
@@ -1,7 +1,7 @@
 
 import XCTest
 
-public protocol Sencha: SenchaScrollableAssertion, SenchaTapActions, SenchaEditTextActions, SenchaSwipeActions, SenchaKeyboardActions, SenchaTableViewAssertions, SenchaSwitchAssertions, SenchaCollectionViewAssertions, SenchaSliderAssertions {}
+public protocol Sencha: SenchaScrollableAssertion, SenchaTapActions, SenchaEditTextActions, SenchaSwipeActions, SenchaKeyboardActions, SenchaTableViewAssertions, SenchaSwitchAssertions, SenchaCollectionViewAssertions, SenchaSliderAssertions, SenchaSliderActions {}
 
 extension XCTestCase: Sencha {
 

--- a/Sencha/Extensions/XCTestCase+Sencha.swift
+++ b/Sencha/Extensions/XCTestCase+Sencha.swift
@@ -1,7 +1,7 @@
 
 import XCTest
 
-public protocol Sencha: SenchaScrollableAssertion, SenchaTapActions, SenchaEditTextActions, SenchaSwipeActions, SenchaKeyboardActions, SenchaTableViewAssertions, SenchaSwitchAssertions, SenchaCollectionViewAssertions {}
+public protocol Sencha: SenchaScrollableAssertion, SenchaTapActions, SenchaEditTextActions, SenchaSwipeActions, SenchaKeyboardActions, SenchaTableViewAssertions, SenchaSwitchAssertions, SenchaCollectionViewAssertions, SenchaSliderAssertions {}
 
 extension XCTestCase: Sencha {
 

--- a/Sencha/Extensions/XCTestCase+Sencha.swift
+++ b/Sencha/Extensions/XCTestCase+Sencha.swift
@@ -1,7 +1,7 @@
 
 import XCTest
 
-public protocol Sencha: SenchaScrollableAssertion, SenchaTapActions, SenchaEditTextActions, SenchaSwipeActions, SenchaKeyboardActions, SenchaTableViewAssertions, SenchaSwitchAssertions, SenchaCollectionViewAssertions, SenchaSliderAssertions, SenchaSliderActions, SenchaPickerActions {}
+public protocol Sencha: SenchaScrollableAssertion, SenchaTapActions, SenchaEditTextActions, SenchaSwipeActions, SenchaKeyboardActions, SenchaTableViewAssertions, SenchaSwitchAssertions, SenchaCollectionViewAssertions, SenchaSliderAssertions, SenchaSliderActions, SenchaPickerActions, SenchaPickerAssertions {}
 
 extension XCTestCase: Sencha {
 

--- a/Sencha/Extensions/XCTestCase+Sencha.swift
+++ b/Sencha/Extensions/XCTestCase+Sencha.swift
@@ -1,7 +1,7 @@
 
 import XCTest
 
-public protocol Sencha: SenchaScrollableAssertion, SenchaTapActions, SenchaEditTextActions, SenchaSwipeActions, SenchaKeyboardActions, SenchaTableViewAssertions, SenchaSwitchAssertions, SenchaCollectionViewAssertions, SenchaSliderAssertions, SenchaSliderActions {}
+public protocol Sencha: SenchaScrollableAssertion, SenchaTapActions, SenchaEditTextActions, SenchaSwipeActions, SenchaKeyboardActions, SenchaTableViewAssertions, SenchaSwitchAssertions, SenchaCollectionViewAssertions, SenchaSliderAssertions, SenchaSliderActions, SenchaPickerActions {}
 
 extension XCTestCase: Sencha {
 

--- a/Sencha/Wrapper/EarlGreyHumanizer.swift
+++ b/Sencha/Wrapper/EarlGreyHumanizer.swift
@@ -2,6 +2,26 @@
 import Foundation
 import EarlGrey
 
+public indirect enum ValueMatcher {
+    case closeTo(Double, Double)
+    case equalTo(Double)
+    case lessThan(Double)
+    case greaterThan(Double)
+
+    func greyMatcher() -> GREYMatcher {
+        switch self {
+        case .closeTo(let value, let delta):
+            return grey_closeTo(value, delta)
+        case .equalTo(let value):
+            return grey_equalTo(value)
+        case .lessThan(let value):
+            return grey_lessThan(value)
+        case .greaterThan(let value):
+            return grey_greaterThan(value)
+        }
+    }
+}
+
 public indirect enum Matcher {
     
     case text(String)
@@ -37,12 +57,8 @@ public indirect enum Matcher {
     case progress(Matcher)
     case scrollViewContentOffset(CGPoint)
     case selected
-    case sliderValue(Matcher)
+    case sliderValue(ValueMatcher)
     case stepperValue(Double)
-    case closeTo(Double, Double)
-    case equalTo(Any)
-    case lessThan(Any)
-    case greaterThan(Any)
     case anything()
     
     public func greyMatcher() -> GREYMatcher {
@@ -117,14 +133,6 @@ public indirect enum Matcher {
             return grey_systemAlertViewShown()
         case .keyWindow:
             return grey_keyWindow()
-        case .closeTo(let value, let delta):
-            return grey_closeTo(value, delta)
-        case .equalTo(let value):
-            return grey_equalTo(value)
-        case .lessThan(let value):
-            return grey_lessThan(value)
-        case .greaterThan(let value):
-            return grey_greaterThan(value)
         case .anything():
             return grey_anything()
         }

--- a/Sencha/Wrapper/EarlGreyHumanizer.swift
+++ b/Sencha/Wrapper/EarlGreyHumanizer.swift
@@ -131,6 +131,40 @@ public indirect enum Matcher {
     }
 }
 
+public indirect enum Action {
+
+    case tap
+    case tapAtPont(CGPoint)
+    case doubleTap
+    case doubleTapAtPoint(CGPoint)
+    case longPress
+    case longPressAtPointWithDuration(CGPoint, Double)
+    case longPressWithDuration(Double)
+    case multipleTapsWithCount(UInt)
+
+    func greyAction() -> GREYAction {
+        switch self {
+        case .tap:
+            return grey_tap()
+        case .tapAtPont(let point):
+            return grey_tapAtPoint(point)
+        case .doubleTap:
+            return grey_doubleTap()
+        case .doubleTapAtPoint(let point):
+            return grey_doubleTapAtPoint(point)
+        case .longPress:
+            return grey_longPress()
+        case .longPressAtPointWithDuration(let point, let duration):
+            return grey_longPressAtPointWithDuration(point, duration)
+        case .longPressWithDuration(let duration):
+            return grey_longPressWithDuration(duration)
+        case .multipleTapsWithCount(let count):
+            return grey_multipleTapsWithCount(count)
+        }
+    }
+}
+
+
 public protocol EarlGreyHumanizer {
     
     func select(_ matcher: Matcher, file: StaticString, line: UInt) -> GREYInteraction

--- a/Sencha/Wrapper/EarlGreyHumanizer.swift
+++ b/Sencha/Wrapper/EarlGreyHumanizer.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 import EarlGrey
 

--- a/Sencha/Wrapper/EarlGreyHumanizer.swift
+++ b/Sencha/Wrapper/EarlGreyHumanizer.swift
@@ -52,8 +52,8 @@ public indirect enum Matcher {
     case userInteractionEnabled
     case switchOn
     case switchOff
+    case pickerColumnValue(Int, String)
     case datePickerValue(Date)
-    case pickerColumnSetToValue(Int, String)
     case layout([Any], Matcher)
     case progress(Matcher)
     case scrollViewContentOffset(CGPoint)
@@ -112,10 +112,10 @@ public indirect enum Matcher {
             return grey_switchWithOnState(true)
         case .switchOff:
             return grey_switchWithOnState(false)
+        case .pickerColumnValue(let column, let value):
+            return grey_pickerColumnSetToValue(column, value)
         case .datePickerValue(let date):
             return grey_datePickerValue(date)
-        case .pickerColumnSetToValue(let column, let value):
-            return grey_pickerColumnSetToValue(column, value)
         case .layout(let constraints, let referenceElement):
             return grey_layout(constraints, referenceElement.greyMatcher())
         case .progress(let comparisonMatcher):
@@ -153,6 +153,8 @@ public indirect enum Action {
     case longPressWithDuration(Double)
     case multipleTapsWithCount(UInt)
     case moveSliderToValue(Double)
+    case setPickerColumnToValue(Int, String)
+    case setPickerDateTo(Date)
 
     func greyAction() -> GREYAction {
         switch self {
@@ -174,6 +176,10 @@ public indirect enum Action {
             return grey_multipleTapsWithCount(count)
         case .moveSliderToValue(let value):
             return grey_moveSliderToValue(Float(value))
+        case .setPickerColumnToValue(let column, let value):
+            return grey_setPickerColumnToValue(column, value)
+        case .setPickerDateTo(let date):
+            return grey_setDate(date)
         }
     }
 }

--- a/Sencha/Wrapper/EarlGreyHumanizer.swift
+++ b/Sencha/Wrapper/EarlGreyHumanizer.swift
@@ -202,11 +202,11 @@ public extension EarlGreyHumanizer {
 }
 
 public extension GREYInteraction {
-    @discardableResult public func assert(_ matcher: @autoclosure () -> Matcher) -> Self {
-        return self.assert(matcher().greyMatcher())
+    @discardableResult public func assert(_ matcher: Matcher) -> Self {
+        return self.assert(matcher.greyMatcher())
     }
 
-    @discardableResult public func perform(_ action: @autoclosure () -> Action) -> Self {
-        return self.perform(action().greyAction())
+    @discardableResult public func perform(_ action: Action) -> Self {
+        return self.perform(action.greyAction())
     }
 }

--- a/Sencha/Wrapper/EarlGreyHumanizer.swift
+++ b/Sencha/Wrapper/EarlGreyHumanizer.swift
@@ -5,12 +5,24 @@ import EarlGrey
 public indirect enum Matcher {
     
     case text(String)
+    case textFieldValue(String)
+    case buttonTitle(String)
     case accessibilityID(String)
     case accessibilityLabel(String)
     case `class`(AnyClass)
+    case conformsTo(Protocol)
+    case respondsTo(Selector)
+    case `nil`
+    case notNil
+    case systemAlertShown
+    case keyWindow
     case firstResponder
     case visible
     case notVisible
+    case interactable
+    case ancestor(Matcher)
+    case descendant(Matcher)
+    case minimumVisisblePercent(Double)
     case not(Matcher)
     case allOf([Matcher])
     case anyOf([Matcher])
@@ -19,18 +31,38 @@ public indirect enum Matcher {
     case enabled
     case userInteractionEnabled
     case switchOn
-    case earlGrey(GREYMatcher)
+    case datePickerValue(Date)
+    case pickerColumnSetToValue(Int, String)
+    case layout([Any], Matcher)
+    case progress(Matcher)
+    case scrollViewContentOffset(CGPoint)
+    case selected
+    case sliderValue(Matcher)
+    case stepperValue(Double)
+    case closeTo(Double, Double)
+    case equalTo(Any)
+    case lessThan(Any)
+    case greaterThan(Any)
+    case anything()
     
     public func greyMatcher() -> GREYMatcher {
         switch self {
         case .text(let text):
             return grey_text(text)
+        case .textFieldValue(let text):
+            return grey_textFieldValue(text)
+        case .buttonTitle(let title):
+            return grey_buttonTitle(title)
         case .accessibilityID(let text):
             return grey_accessibilityID(text)
         case .accessibilityLabel(let text):
             return grey_accessibilityLabel(text)
         case .class(let aClass):
             return grey_kindOfClass(aClass)
+        case .conformsTo(let aProtocol):
+            return grey_conformsToProtocol(aProtocol)
+        case .respondsTo(let selector):
+            return grey_respondsToSelector(selector)
         case .firstResponder:
             return grey_firstResponder()
         case .visible:
@@ -39,6 +71,10 @@ public indirect enum Matcher {
             return grey_notVisible()
         case .not(let matcher):
             return grey_not(matcher.greyMatcher())
+        case .interactable:
+            return grey_interactable()
+        case .minimumVisisblePercent(let percent):
+            return grey_minimumVisiblePercent(CGFloat(percent))
         case .allOf(let matchers):
             return grey_allOf(matchers.map{$0.greyMatcher()})
         case .anyOf(let matchers):
@@ -47,14 +83,50 @@ public indirect enum Matcher {
             return CustomMatcher.firstElementMatcher()
         case .firstElementWith(let matcher):
             return grey_allOf([matcher.greyMatcher(), Matcher.firstElement.greyMatcher()])
+        case .ancestor(let matcher):
+            return grey_ancestor(matcher.greyMatcher())
+        case .descendant(let matcher):
+            return grey_descendant(matcher.greyMatcher())
         case .enabled:
             return grey_enabled()
         case .userInteractionEnabled:
             return grey_userInteractionEnabled()
         case .switchOn:
             return grey_switchWithOnState(true)
-        case .earlGrey(let matcher):
-            return matcher
+        case .datePickerValue(let date):
+            return grey_datePickerValue(date)
+        case .pickerColumnSetToValue(let column, let value):
+            return grey_pickerColumnSetToValue(column, value)
+        case .layout(let constraints, let referenceElement):
+            return grey_layout(constraints, referenceElement.greyMatcher())
+        case .progress(let comparisonMatcher):
+            return grey_progress(comparisonMatcher.greyMatcher())
+        case .scrollViewContentOffset(let offset):
+            return grey_scrollViewContentOffset(offset)
+        case .selected:
+            return grey_selected()
+        case .sliderValue(let valueMatcher):
+            return grey_sliderValueMatcher(valueMatcher.greyMatcher())
+        case .stepperValue(let value):
+            return grey_stepperValue(value)
+        case .nil:
+            return grey_nil()
+        case .notNil:
+            return grey_notNil()
+        case .systemAlertShown:
+            return grey_systemAlertViewShown()
+        case .keyWindow:
+            return grey_keyWindow()
+        case .closeTo(let value, let delta):
+            return grey_closeTo(value, delta)
+        case .equalTo(let value):
+            return grey_equalTo(value)
+        case .lessThan(let value):
+            return grey_lessThan(value)
+        case .greaterThan(let value):
+            return grey_greaterThan(value)
+        case .anything():
+            return grey_anything()
         }
     }
 }

--- a/Sencha/Wrapper/EarlGreyHumanizer.swift
+++ b/Sencha/Wrapper/EarlGreyHumanizer.swift
@@ -51,6 +51,7 @@ public indirect enum Matcher {
     case enabled
     case userInteractionEnabled
     case switchOn
+    case switchOff
     case datePickerValue(Date)
     case pickerColumnSetToValue(Int, String)
     case layout([Any], Matcher)
@@ -109,6 +110,8 @@ public indirect enum Matcher {
             return grey_userInteractionEnabled()
         case .switchOn:
             return grey_switchWithOnState(true)
+        case .switchOff:
+            return grey_switchWithOnState(false)
         case .datePickerValue(let date):
             return grey_datePickerValue(date)
         case .pickerColumnSetToValue(let column, let value):
@@ -149,6 +152,7 @@ public indirect enum Action {
     case longPressAtPointWithDuration(CGPoint, Double)
     case longPressWithDuration(Double)
     case multipleTapsWithCount(UInt)
+    case moveSliderToValue(Double)
 
     func greyAction() -> GREYAction {
         switch self {
@@ -168,10 +172,11 @@ public indirect enum Action {
             return grey_longPressWithDuration(duration)
         case .multipleTapsWithCount(let count):
             return grey_multipleTapsWithCount(count)
+        case .moveSliderToValue(let value):
+            return grey_moveSliderToValue(Float(value))
         }
     }
 }
-
 
 public protocol EarlGreyHumanizer {
     
@@ -193,5 +198,9 @@ public extension EarlGreyHumanizer {
 public extension GREYInteraction {
     @discardableResult public func assert(_ matcher: @autoclosure () -> Matcher) -> Self {
         return self.assert(matcher().greyMatcher())
+    }
+
+    @discardableResult public func perform(_ action: @autoclosure () -> Action) -> Self {
+        return self.perform(action().greyAction())
     }
 }


### PR DESCRIPTION
There have been some additions to EarlGrey library's matchers and actions, so we need wrappers for them too 🌯.

I've also added two separate functions for the type_text and replace_text actions so that we can use them wisely in their appropriate context.