### PR TITLE
Add a method to wait until view controller type is visible

### DIFF
--- a/ExampleProjectTests/MainViewShould.swift
+++ b/ExampleProjectTests/MainViewShould.swift
@@ -72,4 +72,13 @@ class MainViewShould: XCTestCase {
         swipe(.text("1"), inDirection: .left)
         assertVisible(.text("Delete"))
     }
+
+    func test_wait_view_controller_to_be_visible() {
+        assertVisible(.text("Sencha Example"))
+
+        tap(.text("12"), inScrollableElementWith: TABLE_VIEW_MATCHER)
+        waitToBeVisible(viewControllerType: DetailViewController.self)
+
+        assertVisible(.text("Detail"))
+    }
 }

--- a/Sencha/Conditions/SenchaViewControllerCondition.swift
+++ b/Sencha/Conditions/SenchaViewControllerCondition.swift
@@ -17,24 +17,21 @@ struct SenchaViewControllerCondition {
     }
 
     private func topViewController(_ rootViewController: UIViewController) -> UIViewController {
+        var viewController: UIViewController?
+
         switch rootViewController {
         case let navigationController as UINavigationController:
-            return navigationController.topViewController ?? rootViewController
+            viewController = navigationController.topViewController
         case let tabBarController as UITabBarController:
-            guard let selectedViewController = tabBarController.selectedViewController else {
-                return rootViewController
-            }
-            return topViewController(selectedViewController)
+            viewController = tabBarController.selectedViewController
         case let splitViewController as UISplitViewController:
-            guard let viewController = splitViewController.viewControllers.last else {
-                return rootViewController
-            }
-            return topViewController(viewController)
+            viewController = splitViewController.viewControllers.last
         default:
-            guard let presented = rootViewController.presentedViewController else {
-                return rootViewController
-            }
-            return topViewController(presented)
+            viewController = rootViewController.presentedViewController
         }
+        guard let nextViewController = viewController else {
+            return rootViewController
+        }
+        return topViewController(nextViewController)
     }
 }

--- a/Sencha/Conditions/SenchaViewControllerCondition.swift
+++ b/Sencha/Conditions/SenchaViewControllerCondition.swift
@@ -1,0 +1,34 @@
+
+import Foundation
+import EarlGrey
+
+struct SenchaViewControllerCondition {
+    var window: UIWindow
+
+    @discardableResult func waitToBeVisible(_ viewControllerType: UIViewController.Type) -> Bool {
+        let success = GREYCondition.init(name: "Wait ViewController to be visible", block: { () -> Bool in
+            let viewController = self.topViewController(self.window.rootViewController)
+            return viewController?.isKind(of: viewControllerType) ?? false
+        }).wait(withTimeout: 10)
+
+        return success
+    }
+
+    private func topViewController(_ rootViewController: UIViewController?) -> UIViewController? {
+        guard let rootViewController = rootViewController else {
+            return nil
+        }
+
+        switch rootViewController {
+        case let navigationController as UINavigationController:
+            return topViewController(navigationController.viewControllers.last)
+        case let tabBarController as UITabBarController:
+            return topViewController(tabBarController.selectedViewController)
+        default:
+            guard let presented = rootViewController.presentedViewController else {
+                return rootViewController
+            }
+            return topViewController(presented)
+        }
+    }
+}

--- a/Sencha/Extensions/XCTestCase+Sencha.swift
+++ b/Sencha/Extensions/XCTestCase+Sencha.swift
@@ -30,6 +30,11 @@ extension XCTestCase: Sencha {
         }
     }
     
+    public func waitToBeVisible(viewControllerType: UIViewController.Type) {
+        let condition = SenchaViewControllerCondition(window: window)
+        condition.waitToBeVisible(viewControllerType)
+    }
+
     private func embedInNavigationController(_ viewController: UIViewController) -> UIViewController {
         let navigationController = UINavigationController(rootViewController: viewController)
         return navigationController


### PR DESCRIPTION
My app shows a splash screen. How can I make my test wait for the main screen?
Sometimes we want to wait until some view controller will be visible. 

We have followed the EarlGrey approach from the FAQs.
https://github.com/google/EarlGrey/blob/master/docs/faq.md#my-app-shows-a-splash-screen-how-can-i-make-my-test-wait-for-the-main-screen

Also, we search the visible `topViewController` inside a possible containers ( `UINavigationController` or `UITabbarController`) or presented modally (`presentedViewController`).
