### PR TITLE
Added method to check for a matcher in a parent

### DIFF
--- a/Sencha/Assertions/SenchaAssertion.swift
+++ b/Sencha/Assertions/SenchaAssertion.swift
@@ -8,49 +8,56 @@ public protocol SenchaAssertion: EarlGreyHumanizer {
     func assertNotVisible(_ matcher: Matcher, file: StaticString, line: UInt)
     func assertEnabled(_ matcher: Matcher, file: StaticString, line: UInt)
     func assertDisabled(_ matcher: Matcher, file: StaticString, line: UInt)
+    func assertVisible(_ matcher: Matcher, inParent parentMatcher: Matcher, file: StaticString, line: UInt)
+    func assertNotVisible(_ matcher: Matcher, inParent parentMatcher: Matcher, file: StaticString, line: UInt)
+    func assertEnabled(_ matcher: Matcher, inParent parentMatcher: Matcher, file: StaticString, line: UInt)
+    func assertDisabled(_ matcher: Matcher, inParent parentMatcher: Matcher, file: StaticString, line: UInt)
 }
 
 public extension SenchaAssertion {
-    
+
     func assertVisible(_ matcher: Matcher, file: StaticString = #file, line: UInt = #line) {
-        
-        select(
-            matcher,
-            file: file,
-            line: line
-        ).assert(
-            .visible
-        )
+        assert(.visible, matcher: matcher, file: file, line: line)
     }
 
     func assertNotVisible(_ matcher: Matcher, file: StaticString = #file, line: UInt = #line) {
-        
-        select(
-            matcher,
-            file: file,
-            line: line
-        ).assert(
-            .notVisible
-        )
+        assert(.notVisible, matcher: matcher, file: file, line: line)
     }
-    
+
     func assertEnabled(_ matcher: Matcher, file: StaticString = #file, line: UInt = #line) {
-        select(
-            matcher,
-            file: file,
-            line: line
-        ).assert(
-            .enabled
-        )
+        assert(.enabled, matcher: matcher, file: file, line: line)
+    }
+
+    func assertDisabled(_ matcher: Matcher, file: StaticString = #file, line: UInt = #line) {
+        assert(.not(.enabled), matcher: matcher, file: file, line: line)
     }
     
-    func assertDisabled(_ matcher: Matcher, file: StaticString = #file, line: UInt = #line) {
-        select(
-            matcher,
-            file: file,
-            line: line
+    func assertVisible(_ matcher: Matcher, inParent parentMatcher: Matcher, file: StaticString = #file, line: UInt = #line) {
+        assert(.visible, matcher: matcher, inParent: parentMatcher, file: file, line: line)
+    }
+
+    func assertNotVisible(_ matcher: Matcher, inParent parentMatcher: Matcher, file: StaticString = #file, line: UInt = #line) {
+        assert(.notVisible, matcher: matcher, inParent: parentMatcher, file: file, line: line)
+    }
+    
+    func assertEnabled(_ matcher: Matcher, inParent parentMatcher: Matcher, file: StaticString = #file, line: UInt = #line) {
+        assert(.enabled, matcher: matcher, inParent: parentMatcher, file: file, line: line)
+    }
+    
+    func assertDisabled(_ matcher: Matcher, inParent parentMatcher: Matcher, file: StaticString = #file, line: UInt = #line) {
+        assert(.not(.enabled), matcher: matcher, inParent: parentMatcher, file: file, line: line)
+    }
+
+    private func assert(_ assertion: Matcher, matcher: Matcher, inParent parentMatcher: Matcher? = nil, file: StaticString = #file, line: UInt = #line) {
+        let interaction = select(matcher, file: file, line: line)
+        guard let parentMatcher = parentMatcher else {
+            interaction.assert(assertion)
+            return
+        }
+        interaction.inRoot(
+                parentMatcher.greyMatcher()
         ).assert(
-            .not(.enabled)
+                assertion
         )
     }
 }


### PR DESCRIPTION
When trying to find a Matcher that is possibly duplicated, EarlyGrey will throw an exception. For this reason I added alternative methods:

```
    func assertVisible(_ matcher: Matcher, inParent parentMatcher: Matcher)
    func assertNotVisible(_ matcher: Matcher, inParent parentMatcher: Matcher)
    func assertEnabled(_ matcher: Matcher, inParent parentMatcher: Matcher)
    func assertDisabled(_ matcher: Matcher, inParent parentMatcher: Matcher)
```
That allow to search for a Matcher only within a given `parentMatcher`.

